### PR TITLE
add minefied indicator

### DIFF
--- a/indicator/multi/bbi_hpi_rsi.pine
+++ b/indicator/multi/bbi_hpi_rsi.pine
@@ -122,11 +122,14 @@ new_rsi(src, rsl, rsp) =>
 // -------------------------------------------------------------------------- //
 
 
+
 // new short trend indicator
 new_sti() =>
-    bbi = new_bbi(close, bbl, bbs)
-    hpi = new_hpi(close, hrb, hpc)
-    rsi = new_rsi(close, rsl, rsp)
+    src = close
+
+    bbi = new_bbi(src, bbl, bbs)
+    hpi = new_hpi(src, hrb, hpc)
+    rsi = new_rsi(src, rsl, rsp)
 
     bhi = (bbi[0] and hpi[0]) or (bbi[0] and hpi[1]) or (bbi[1] and hpi[0])
     bri = (bbi[0] and rsi[0]) or (bbi[0] and rsi[1]) or (bbi[1] and rsi[0])
@@ -137,3 +140,17 @@ new_sti() =>
 
 
 plotshape(new_sti(), text="SHORT", location=location.abovebar, style=shape.labeldown, size=size.tiny, color=color.red, textcolor=color.white, transp=0)
+
+
+
+// TODO minefield indicator, we need multiple bands crossing in price increase
+// situations in order to cancel out false positive short signals.
+
+mal = input(title="MFIA Length", type=input.integer, defval=100,  minval=1,    step=1   )
+mas = input(title="MFIA Stddev", type=input.float,   defval=0.75, minval=0.05, step=0.05)
+
+mbl = input(title="MFIB Length", type=input.integer, defval=200,  minval=1,    step=1   )
+mbs = input(title="MFIB Stddev", type=input.float,   defval=0.75, minval=0.05, step=0.05)
+
+plot(new_bbu(close, mal, mas), "MFI", color=color.white, transp=50)
+plot(new_bbu(close, mbl, mbs), "MFI", color=color.blue,  transp=50)

--- a/indicator/single/bollinger_band.pine
+++ b/indicator/single/bollinger_band.pine
@@ -6,7 +6,7 @@
 
 
 
-study(title="BB", shorttitle="BB", overlay=true)
+study(title="BBI", shorttitle="BBI", overlay=true)
 
 
 
@@ -14,8 +14,8 @@ study(title="BB", shorttitle="BB", overlay=true)
 
 
 
-bbl = input(title="BB Length", type=input.integer, defval=21,  minval=1,   step=1  )
-bbs = input(title="BB Stddev", type=input.float,   defval=2.0, minval=0.1, step=0.1)
+// bbl = input(title="BB Length", type=input.integer, defval=50,  minval=1,    step=1   )
+// bbs = input(title="BB Stddev", type=input.float,   defval=1.5, minval=0.01, step=0.05)
 
 
 
@@ -49,6 +49,10 @@ new_bbi(src, bbl, bbs) =>
 
 
 
-plot(new_bbu(close, bbl, bbs), "BB Up", color=color.gray)
+// plot(new_bbu(close, 100, 1.25), "BBI", color=color.white, transp=50)
+// plot(new_bbu(close, 300, 0.75), "BBI", color=color.blue,  transp=50)
 
-plotshape(new_bbi(close, bbl, bbs), text="BBI", location=location.abovebar, style=shape.labeldown, size=size.tiny, color=color.red, textcolor=color.white, transp=0)
+one = new_bbu(close, 100, 1.25)
+two = new_bbu(close, 300, 0.75)
+
+plotshape(cross(one, two) and close > one, text="BBI", location=location.abovebar, style=shape.labeldown, size=size.tiny, color=color.red, textcolor=color.white, transp=0)


### PR DESCRIPTION
The minefield indicator aims to cancel out false positives. Therefore multiple moving averages are necessary in different configurations. 

<img width="1920" alt="Screenshot 2020-12-07 at 00 18 07" src="https://user-images.githubusercontent.com/552769/101296066-b06de380-3821-11eb-9153-7d11cbde2002.png">
